### PR TITLE
feat: build the database schema

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -8,6 +8,17 @@
 #
 # Non-secret Discord IDs (guild, roles, channels) are NOT env vars: they live in
 # src/consts/discord.ts.
+#
+# TWO TARGETS. Every credential exists twice — once for the clan's real
+# services, once for their throwaway counterparts (the `rats-site-dev`
+# database, and the `RATS HQ Dev` application in its test guild). The
+# development names carry a _DEV_ infix.
+#
+# `next dev` and Vercel previews resolve to the DEVELOPMENT target and read
+# only the _DEV_ names — there is deliberately no fallback to production, so a
+# half-configured dev setup fails loudly instead of writing to real data.
+# Vercel production, and one-off scripts like `make check-provisioning`,
+# resolve to PRODUCTION. Override either with APP_ENV=development|production.
 
 # --- Discord bot ---------------------------------------------------------
 # https://discord.com/developers/applications → your app → Bot → Reset Token
@@ -30,3 +41,15 @@ DISCORD_REDIRECT_URI=http://localhost:3000/api/auth/callback
 # libsql:// and https:// are Turso; file: is the self-hosted exit path.
 TURSO_DATABASE_URL=
 TURSO_AUTH_TOKEN=
+
+# --- Development counterparts --------------------------------------------
+# The RATS HQ Dev application, alone in its test guild (#29).
+DISCORD_DEV_BOT_TOKEN=
+DISCORD_DEV_CLIENT_ID=
+DISCORD_DEV_CLIENT_SECRET=
+DISCORD_DEV_REDIRECT_URI=http://localhost:3000/api/auth/callback
+
+# The rats-site-dev database. `make db-migrate` targets this one; production
+# needs `make db-migrate-prod`, by name.
+TURSO_DEV_DATABASE_URL=
+TURSO_DEV_AUTH_TOKEN=

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,3 +33,13 @@ _Avoid_: Officer (that's the Discord role name), SL, leader
 **RATS HQ**:
 The clan's own Discord bot — one Team-owned application, replacing the third-party bots in the guild. It owns every Discord write: the site writes rows, RATS HQ makes Discord match them. Its throwaway development counterpart is a separate application, `RATS HQ Dev`, which lives alone in a test guild and never joins the RATS guild.
 _Avoid_: The bot (unqualified), the integration, Integration Helper (the retired application)
+
+**Roster post**:
+The Discord message that projects a published event's rounds and squads. RATS HQ re-renders it wholesale from the rows and edits it in place; it is never republished, so an event has at most one Roster post for its whole life.
+_Avoid_: The roster message, the embed, the announcement
+
+**Call-up**:
+A message posted beneath a Roster post, mentioning only the Members whose slots changed since the previous one — added, moved or removed. One per batch of changes, kept as history rather than replaced, because it is the record of who was told what and when.
+_Avoid_: Ping, tag, notification, mention message
+
+> **On the word "publish":** it names the state transition — an event gaining a publication time — not the message. The message is the **Roster post**, and it outlives every later edit.

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,23 @@ discord-channels: ## List Discord channel IDs
 check-provisioning: ## Verify credentials, channel IDs and bot permissions (issue #14)
 	npx --no-install tsx --env-file=.env.local scripts/check-provisioning.ts
 
+# ── Database ───────────────────────────────────────────────
+# Everything here targets the DEV database unless the target says otherwise:
+# migrating the clan's real data has to be asked for by name.
+.PHONY: db-generate db-migrate db-migrate-prod db-studio
+
+db-generate: ## Generate a migration from the schema (touches no database)
+	npx --no-install drizzle-kit generate
+
+db-migrate: ## Apply pending migrations to the DEV database
+	set -a && . ./.env.local && set +a && npx --no-install drizzle-kit migrate
+
+db-migrate-prod: ## Apply pending migrations to PRODUCTION — the clan's real data
+	set -a && . ./.env.local && set +a && APP_ENV=production npx --no-install drizzle-kit migrate
+
+db-studio: ## Browse the DEV database in Drizzle Studio
+	set -a && . ./.env.local && set +a && npx --no-install drizzle-kit studio
+
 # ── Provisioning tools ─────────────────────────────────────
 .PHONY: tools-build tools-shell turso vercel
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from "drizzle-kit";
+
+/**
+ * drizzle-kit reads credentials straight from the environment rather than
+ * through `src/lib/env.ts`, because it runs as a CLI outside Next.js and the
+ * `@/` path alias is not available to it. The target selection is duplicated
+ * here deliberately and kept trivial.
+ *
+ * **Defaults to the development database.** Migrating the clan's real data has
+ * to be a thing you asked for by name — `make db-migrate-prod`, which sets
+ * `APP_ENV=production`.
+ *
+ * Prisma Migrate does not work over Turso's HTTP protocol (#8); drizzle-kit
+ * does, which is half the reason Drizzle won.
+ */
+const isProduction = process.env.APP_ENV === "production";
+
+const url = isProduction
+  ? process.env.TURSO_DATABASE_URL
+  : process.env.TURSO_DEV_DATABASE_URL;
+
+const authToken = isProduction
+  ? process.env.TURSO_AUTH_TOKEN
+  : process.env.TURSO_DEV_AUTH_TOKEN;
+
+if (!url) {
+  throw new Error(
+    `No ${isProduction ? "TURSO_DATABASE_URL" : "TURSO_DEV_DATABASE_URL"} set — ` +
+      "load it with `set -a && . ./.env.local`, as the make targets do.",
+  );
+}
+
+export default defineConfig({
+  dialect: "turso",
+  schema: "./src/db/schema/create_table_*.ts",
+  out: "./drizzle",
+  dbCredentials: { url, authToken },
+});

--- a/drizzle/0000_shallow_ultragirl.sql
+++ b/drizzle/0000_shallow_ultragirl.sql
@@ -1,0 +1,87 @@
+CREATE TABLE `event_rsvps` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`event_id` integer NOT NULL,
+	`member_id` text,
+	`apollo_raw_name` text NOT NULL,
+	`status` text NOT NULL,
+	`imported_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`event_id`) REFERENCES `events`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`member_id`) REFERENCES `members`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `event_rsvps_event_idx` ON `event_rsvps` (`event_id`);--> statement-breakpoint
+CREATE TABLE `events` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`apollo_message_link` text NOT NULL,
+	`apollo_message_id` text NOT NULL,
+	`date` integer NOT NULL,
+	`published_at` integer,
+	`discord_message_id` text
+);
+--> statement-breakpoint
+CREATE TABLE `member_aliases` (
+	`alias` text PRIMARY KEY NOT NULL,
+	`member_id` text NOT NULL,
+	FOREIGN KEY (`member_id`) REFERENCES `members`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `member_roles` (
+	`member_id` text NOT NULL,
+	`role` text NOT NULL,
+	`preference` integer,
+	PRIMARY KEY(`member_id`, `role`),
+	FOREIGN KEY (`member_id`) REFERENCES `members`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `member_roles_preference_idx` ON `member_roles` (`member_id`,`preference`);--> statement-breakpoint
+CREATE INDEX `member_roles_role_idx` ON `member_roles` (`role`);--> statement-breakpoint
+CREATE TABLE `members` (
+	`id` text PRIMARY KEY NOT NULL,
+	`callsign` text NOT NULL,
+	`rank` text NOT NULL,
+	`roles_synced_at` integer,
+	`steam_id` text,
+	`direction_primary` text,
+	`direction_secondary` text,
+	`birth_day` integer,
+	`birth_month` integer,
+	`birth_year` integer,
+	`is_left` integer DEFAULT false NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `members_birthday_idx` ON `members` (`birth_month`,`birth_day`);--> statement-breakpoint
+CREATE INDEX `members_is_left_idx` ON `members` (`is_left`);--> statement-breakpoint
+CREATE TABLE `rounds` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`event_id` integer NOT NULL,
+	`ordinal` integer NOT NULL,
+	`faction` text NOT NULL,
+	`layer` text NOT NULL,
+	FOREIGN KEY (`event_id`) REFERENCES `events`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `rounds_event_idx` ON `rounds` (`event_id`);--> statement-breakpoint
+CREATE TABLE `slots` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`squad_id` integer NOT NULL,
+	`member_id` text NOT NULL,
+	`role` text,
+	`removed_at` integer,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`squad_id`) REFERENCES `squads`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`member_id`) REFERENCES `members`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `slots_squad_idx` ON `slots` (`squad_id`);--> statement-breakpoint
+CREATE INDEX `slots_member_idx` ON `slots` (`member_id`);--> statement-breakpoint
+CREATE TABLE `squads` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`round_id` integer NOT NULL,
+	`name` text NOT NULL,
+	`type_tag` text,
+	FOREIGN KEY (`round_id`) REFERENCES `rounds`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `squads_round_idx` ON `squads` (`round_id`);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,607 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a4ece9b2-1c1d-44e1-b7e7-3ec41a66b213",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "event_rsvps": {
+      "name": "event_rsvps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "apollo_raw_name": {
+          "name": "apollo_raw_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "event_rsvps_event_idx": {
+          "name": "event_rsvps_event_idx",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_rsvps_event_id_events_id_fk": {
+          "name": "event_rsvps_event_id_events_id_fk",
+          "tableFrom": "event_rsvps",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_rsvps_member_id_members_id_fk": {
+          "name": "event_rsvps_member_id_members_id_fk",
+          "tableFrom": "event_rsvps",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "apollo_message_link": {
+          "name": "apollo_message_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "apollo_message_id": {
+          "name": "apollo_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member_aliases": {
+      "name": "member_aliases",
+      "columns": {
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_aliases_member_id_members_id_fk": {
+          "name": "member_aliases_member_id_members_id_fk",
+          "tableFrom": "member_aliases",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member_roles": {
+      "name": "member_roles",
+      "columns": {
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preference": {
+          "name": "preference",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "member_roles_preference_idx": {
+          "name": "member_roles_preference_idx",
+          "columns": [
+            "member_id",
+            "preference"
+          ],
+          "isUnique": true
+        },
+        "member_roles_role_idx": {
+          "name": "member_roles_role_idx",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_roles_member_id_members_id_fk": {
+          "name": "member_roles_member_id_members_id_fk",
+          "tableFrom": "member_roles",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "member_roles_member_id_role_pk": {
+          "columns": [
+            "member_id",
+            "role"
+          ],
+          "name": "member_roles_member_id_role_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "members": {
+      "name": "members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "callsign": {
+          "name": "callsign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "roles_synced_at": {
+          "name": "roles_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "steam_id": {
+          "name": "steam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "direction_primary": {
+          "name": "direction_primary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "direction_secondary": {
+          "name": "direction_secondary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "birth_day": {
+          "name": "birth_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "birth_month": {
+          "name": "birth_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "birth_year": {
+          "name": "birth_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_left": {
+          "name": "is_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "members_birthday_idx": {
+          "name": "members_birthday_idx",
+          "columns": [
+            "birth_month",
+            "birth_day"
+          ],
+          "isUnique": false
+        },
+        "members_is_left_idx": {
+          "name": "members_is_left_idx",
+          "columns": [
+            "is_left"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rounds": {
+      "name": "rounds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "faction": {
+          "name": "faction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "layer": {
+          "name": "layer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rounds_event_idx": {
+          "name": "rounds_event_idx",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rounds_event_id_events_id_fk": {
+          "name": "rounds_event_id_events_id_fk",
+          "tableFrom": "rounds",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slots": {
+      "name": "slots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "squad_id": {
+          "name": "squad_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "slots_squad_idx": {
+          "name": "slots_squad_idx",
+          "columns": [
+            "squad_id"
+          ],
+          "isUnique": false
+        },
+        "slots_member_idx": {
+          "name": "slots_member_idx",
+          "columns": [
+            "member_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "slots_squad_id_squads_id_fk": {
+          "name": "slots_squad_id_squads_id_fk",
+          "tableFrom": "slots",
+          "tableTo": "squads",
+          "columnsFrom": [
+            "squad_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "slots_member_id_members_id_fk": {
+          "name": "slots_member_id_members_id_fk",
+          "tableFrom": "slots",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "squads": {
+      "name": "squads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type_tag": {
+          "name": "type_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "squads_round_idx": {
+          "name": "squads_round_idx",
+          "columns": [
+            "round_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "squads_round_id_rounds_id_fk": {
+          "name": "squads_round_id_rounds_id_fk",
+          "tableFrom": "squads",
+          "tableTo": "rounds",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1787109421983,
+      "tag": "0000_shallow_ultragirl",
+      "breakpoints": true
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "rats-site",
       "version": "0.1.0",
       "dependencies": {
+        "@libsql/client": "^0.17.4",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
         "clsx": "^2.1.1",
+        "drizzle-orm": "^0.45.2",
         "framer-motion": "12.43.0",
         "lenis": "^1.3.25",
         "lucide-react": "^1.27.0",
@@ -24,6 +26,7 @@
         "@types/node": "^26.1.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "drizzle-kit": "^0.31.10",
         "eslint": "^9.39.5",
         "eslint-config-next": "16.2.12",
         "tailwindcss": "^4.3.3",
@@ -312,6 +315,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@drizzle-team/brocli": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
+      "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@emnapi/core": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
@@ -343,6 +353,442 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
+      "integrity": "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==",
+      "deprecated": "Merged into tsx: https://tsx.hirok.io",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.18.20",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/@esbuild-kit/esm-loader": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.6.5.tgz",
+      "integrity": "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==",
+      "deprecated": "Merged into tsx: https://tsx.hirok.io",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.3.2",
+        "get-tsconfig": "^4.7.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1559,6 +2005,165 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@libsql/client": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.4.tgz",
+      "integrity": "sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@libsql/core": "^0.17.4",
+        "@libsql/hrana-client": "^0.10.0",
+        "js-base64": "^3.7.5",
+        "libsql": "^0.5.28",
+        "promise-limit": "^2.7.0"
+      }
+    },
+    "node_modules/@libsql/core": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@libsql/core/-/core-0.17.4.tgz",
+      "integrity": "sha512-LqF9gIvnJ38nmAH1y/ChizHqDO/MO1wLgA96XrraulEEbqXxLjleSH92YWTolbuJKgPUmGu4aJk9W3UnAcxLOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "js-base64": "^3.7.5"
+      }
+    },
+    "node_modules/@libsql/darwin-arm64": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.5.29.tgz",
+      "integrity": "sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@libsql/darwin-x64": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.5.29.tgz",
+      "integrity": "sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@libsql/hrana-client": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.10.0.tgz",
+      "integrity": "sha512-OoA4EMqRAC7kn7V2P6EQqRcpZf2W+AjsNIyCizBg339Tq/aMC7sRnzs3SklderhmQWAqEzvv8A2vhxVmWpkVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@libsql/isomorphic-ws": "^0.1.5",
+        "js-base64": "^3.7.5"
+      }
+    },
+    "node_modules/@libsql/isomorphic-ws": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-ws/-/isomorphic-ws-0.1.5.tgz",
+      "integrity": "sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ws": "^8.5.4",
+        "ws": "^8.13.0"
+      }
+    },
+    "node_modules/@libsql/linux-arm-gnueabihf": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.5.29.tgz",
+      "integrity": "sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm-musleabihf": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm-musleabihf/-/linux-arm-musleabihf-0.5.29.tgz",
+      "integrity": "sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm64-gnu": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.5.29.tgz",
+      "integrity": "sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm64-musl": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.5.29.tgz",
+      "integrity": "sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-gnu": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.5.29.tgz",
+      "integrity": "sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-musl": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.5.29.tgz",
+      "integrity": "sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/win32-x64-msvc": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.5.29.tgz",
+      "integrity": "sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1571,6 +2176,12 @@
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
       }
+    },
+    "node_modules/@neon-rs/load": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
+      "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==",
+      "license": "MIT"
     },
     "node_modules/@next/env": {
       "version": "16.2.12",
@@ -2472,7 +3083,6 @@
       "version": "26.1.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
       "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -2494,6 +3104,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -3383,6 +4002,13 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "dev": true,
@@ -3655,6 +4281,631 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/drizzle-kit": {
+      "version": "0.31.10",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.10.tgz",
+      "integrity": "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@drizzle-team/brocli": "^0.10.2",
+        "@esbuild-kit/esm-loader": "^2.5.5",
+        "esbuild": "^0.25.4",
+        "tsx": "^4.21.0"
+      },
+      "bin": {
+        "drizzle-kit": "bin.cjs"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/drizzle-orm": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
+      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
       }
     },
     "node_modules/dunder-proto": {
@@ -5438,6 +6689,12 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-base64": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.3.tgz",
+      "integrity": "sha512-uwYQp+VJ38FVvtim6qNbit6e9uT6dwWQ4Y1+H9TxhW5hcHjpHwoxlR0nMpqUmIFOmu4VqMxwdJA88gIVuZJQ/g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "dev": true,
@@ -5586,6 +6843,47 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/libsql": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.5.29.tgz",
+      "integrity": "sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==",
+      "cpu": [
+        "x64",
+        "arm64",
+        "wasm32",
+        "arm"
+      ],
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "@neon-rs/load": "^0.0.4",
+        "detect-libc": "2.0.2"
+      },
+      "optionalDependencies": {
+        "@libsql/darwin-arm64": "0.5.29",
+        "@libsql/darwin-x64": "0.5.29",
+        "@libsql/linux-arm-gnueabihf": "0.5.29",
+        "@libsql/linux-arm-musleabihf": "0.5.29",
+        "@libsql/linux-arm64-gnu": "0.5.29",
+        "@libsql/linux-arm64-musl": "0.5.29",
+        "@libsql/linux-x64-gnu": "0.5.29",
+        "@libsql/linux-x64-musl": "0.5.29",
+        "@libsql/win32-x64-msvc": "0.5.29"
+      }
+    },
+    "node_modules/libsql/node_modules/detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lightningcss": {
@@ -6417,6 +7715,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/promise-limit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+      "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
+      "license": "ISC"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "dev": true,
@@ -6883,11 +8187,32 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/stable-hash": {
@@ -7337,7 +8662,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -7700,6 +9024,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@libsql/client": "^0.17.4",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "clsx": "^2.1.1",
+    "drizzle-orm": "^0.45.2",
     "framer-motion": "12.43.0",
     "lenis": "^1.3.25",
     "lucide-react": "^1.27.0",
@@ -27,6 +29,7 @@
     "@types/node": "^26.1.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "drizzle-kit": "^0.31.10",
     "eslint": "^9.39.5",
     "eslint-config-next": "16.2.12",
     "tailwindcss": "^4.3.3",

--- a/src/consts/discord.ts
+++ b/src/consts/discord.ts
@@ -17,6 +17,12 @@ export const ROLE_VO_DUCHE = "1249808893400449064";
 export const ROLE_OFFICER = "1249806255388627015";
 // "RATS" — regular members
 export const ROLE_RATS = "1249804025667260467";
+// "Recruit" — on trial, not yet a full member
+export const ROLE_RECRUIT = "1249802231054860401";
+// "Inactive" — a declared leave of absence, granted on the member's own
+// request. NOT the same as having left: an Inactive member is still in the
+// guild, which is why `members.is_left` is a separate fact.
+export const ROLE_INACTIVE = "1278662254522273793";
 
 /**
  * Maps Discord role IDs to display labels shown on the site.

--- a/src/consts/squad.test.ts
+++ b/src/consts/squad.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DIRECTION_LABELS,
+  DIRECTIONS,
+  MAX_ROLE_PREFERENCES,
+  RANKS,
+  SQUAD_ROLE_HINTS,
+  SQUAD_ROLE_LABELS,
+  SQUAD_ROLES,
+} from "./squad";
+
+describe("Squad roles", () => {
+  it("has the fourteen kits the clan plays", () => {
+    expect(SQUAD_ROLES).toHaveLength(14);
+  });
+
+  it("labels every one of them", () => {
+    for (const role of SQUAD_ROLES) {
+      expect(SQUAD_ROLE_LABELS[role]).toBeTruthy();
+    }
+  });
+
+  it("distinguishes the three Tech tiers by their vehicles", () => {
+    // The tiers are meaningless without them — «Tech middle» tells nobody
+    // whether they are being asked to crew a BTR.
+    expect(SQUAD_ROLE_HINTS.TECH_LIGHT).toBe("RWS, BRDM");
+    expect(SQUAD_ROLE_HINTS.TECH_MIDDLE).toBe("BTR, LAV");
+    expect(SQUAD_ROLE_HINTS.TECH_HEAVY).toBe("Tank, ZBD");
+  });
+
+  it("has no duplicates", () => {
+    expect(new Set(SQUAD_ROLES).size).toBe(SQUAD_ROLES.length);
+  });
+});
+
+describe("Напрями", () => {
+  // Issue #18 corrected these from four to six, against the clan's written
+  // squad doctrine. The four-item list came from CSV column values and is
+  // still present in the profile prototype — this test is the guard.
+  it("has six, including VIC and MORTAR", () => {
+    expect(DIRECTIONS).toHaveLength(6);
+    expect(DIRECTIONS).toContain("VIC");
+    expect(DIRECTIONS).toContain("MORTAR");
+  });
+
+  it("carries the Ukrainian gloss for every one", () => {
+    for (const direction of DIRECTIONS) {
+      expect(DIRECTION_LABELS[direction]).toBeTruthy();
+    }
+  });
+});
+
+describe("Ranks", () => {
+  it("includes Recruit and Inactive", () => {
+    // Both are real Discord roles that were missing from the constants, and
+    // `members.rank` cannot be populated correctly without them (#12, #13).
+    expect(RANKS).toContain("RECRUIT");
+    expect(RANKS).toContain("INACTIVE");
+  });
+});
+
+describe("preferences", () => {
+  it("caps the top-N at three", () => {
+    expect(MAX_ROLE_PREFERENCES).toBe(3);
+  });
+});

--- a/src/consts/squad.ts
+++ b/src/consts/squad.ts
@@ -1,0 +1,112 @@
+/**
+ * The in-game taxonomy: what a Member can do, and where they belong.
+ *
+ * These two lists are the single source of truth for their columns. Drizzle's
+ * `text({ enum })` types the column in TypeScript; the stored SQLite type is
+ * plain TEXT. There are deliberately no CHECK constraints and no lookup
+ * tables — SQLite cannot ALTER a constraint, so a fifteenth Squad role would
+ * rebuild the table, and this taxonomy only changes when Squad itself does.
+ * The trade accepted: a bad value can only enter by bypassing the app.
+ */
+
+/**
+ * The fourteen in-game kits a Member can play — «Ролі».
+ *
+ * Always qualify this as a *Squad role*: `CONTEXT.md` reserves bare "role" as
+ * ambiguous, and this is a fourth meaning alongside Rank and Discord role.
+ */
+export const SQUAD_ROLES = [
+  "RIFLER",
+  "MEDIC",
+  "LAT",
+  "HAT",
+  "GL",
+  "MG",
+  "MARKSMAN",
+  "CE",
+  "SL",
+  "TECH_LIGHT",
+  "TECH_MIDDLE",
+  "TECH_HEAVY",
+  "PILOT",
+  "MORTAR",
+] as const;
+
+export type SquadRole = (typeof SQUAD_ROLES)[number];
+
+/** English labels, matching how the clan writes them in Discord. */
+export const SQUAD_ROLE_LABELS: Record<SquadRole, string> = {
+  RIFLER: "Rifler",
+  MEDIC: "Medic",
+  LAT: "LAT",
+  HAT: "HAT",
+  GL: "GL",
+  MG: "MG",
+  MARKSMAN: "Marksman",
+  CE: "CE",
+  SL: "SL",
+  TECH_LIGHT: "Tech light",
+  TECH_MIDDLE: "Tech middle",
+  TECH_HEAVY: "Tech heavy",
+  PILOT: "Pilot",
+  MORTAR: "Mortar",
+};
+
+/** Which vehicles each Tech tier covers, shown beside the label on the form. */
+export const SQUAD_ROLE_HINTS: Partial<Record<SquadRole, string>> = {
+  TECH_LIGHT: "RWS, BRDM",
+  TECH_MIDDLE: "BTR, LAV",
+  TECH_HEAVY: "Tank, ZBD",
+};
+
+/** How many Squad roles a Member may rank as a preference. A maximum, not a quota. */
+export const MAX_ROLE_PREFERENCES = 3;
+
+/**
+ * The six «напрями» — the type of загін a Member belongs in.
+ *
+ * A напрямок is a *type of squad*, not a position on the map, which is why
+ * the same enum serves `members.direction_primary` and `squads.type_tag`.
+ * Corrected from four by issue #18, against the clan's written squad doctrine.
+ */
+export const DIRECTIONS = [
+  "FRONTLINE",
+  "BACKLINE",
+  "FLANK",
+  "FLEX",
+  "VIC",
+  "MORTAR",
+] as const;
+
+export type Direction = (typeof DIRECTIONS)[number];
+
+/**
+ * The Ukrainian gloss shown alongside the English label. Issue #18 settled the
+ * form as English label + gloss, matching the Squad role tiles.
+ */
+export const DIRECTION_LABELS: Record<Direction, string> = {
+  FRONTLINE: "ФРОНТ",
+  BACKLINE: "ТИЛ",
+  FLANK: "ФЛАНГ",
+  FLEX: "ФЛЕКС",
+  VIC: "ТЕХНІКА",
+  MORTAR: "МІНОМЕТ",
+};
+
+/**
+ * The Ranks a Member can hold, derived from their Discord roles.
+ *
+ * Denormalised onto `members.rank` for display and filtering only — the
+ * permission tier is resolved live from the session on every request and
+ * never reads the column.
+ */
+export const RANKS = [
+  "DUCHE",
+  "VO_DUCHE",
+  "OFFICER",
+  "RATS",
+  "RECRUIT",
+  "INACTIVE",
+] as const;
+
+export type Rank = (typeof RANKS)[number];

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,42 @@
+/**
+ * The one place that knows how to reach the database.
+ *
+ * #8 settled the exit path: moving off Turso to a self-hosted SQLite file is
+ * a change to `url` alone — same client, same queries — so this module owns
+ * the URL and the credentials, and nothing else. Callers import `db` and the
+ * tables; they never construct a client.
+ *
+ * Instantiated at module scope: Vercel Functions reuse the module across
+ * invocations on a warm instance, and the libSQL client is HTTP-based with no
+ * connection pool to exhaust.
+ */
+
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+
+import { readServerEnv } from "@/lib/env";
+
+import * as schema from "./schema";
+
+function createDb() {
+  const result = readServerEnv(process.env);
+
+  if (!result.ok) {
+    // Fail loudly at first use rather than returning a client that 401s on
+    // every query — `make check-provisioning` is the tool for diagnosing which
+    // credential is missing.
+    const keys = result.problems.map((p) => `${p.key} (${p.reason})`).join(", ");
+    throw new Error(`Database unavailable — bad server environment: ${keys}`);
+  }
+
+  const client = createClient({
+    url: result.config.tursoDatabaseUrl,
+    authToken: result.config.tursoAuthToken,
+  });
+
+  return drizzle(client, { schema });
+}
+
+export const db = createDb();
+
+export * from "./schema";

--- a/src/db/schema/columns.ts
+++ b/src/db/schema/columns.ts
@@ -1,0 +1,16 @@
+/**
+ * Column helpers shared across the tables.
+ *
+ * Every table file imports from here rather than redefining the timestamp
+ * shape, so «what does a date look like in this database» has one answer.
+ */
+
+import { sql } from "drizzle-orm";
+import { integer } from "drizzle-orm/sqlite-core";
+
+/** Unix seconds. SQLite has no date type, and Turso is SQLite. */
+export const timestamp = (name: string) =>
+  integer(name, { mode: "timestamp" });
+
+/** Default for `created_at` / `updated_at`, evaluated by SQLite itself. */
+export const now = sql`(unixepoch())`;

--- a/src/db/schema/create_table_event_rsvps.ts
+++ b/src/db/schema/create_table_event_rsvps.ts
@@ -1,0 +1,40 @@
+/**
+ * TRANSIENT — never history.
+ *
+ * Replaced wholesale on refresh (delete-then-insert for the event, never
+ * merged) and lazy-purged 5 days after `events.date`, swept at the start of
+ * every import since Vercel has no background daemon. This table therefore
+ * can never become a record of who attended what — which is why attendance
+ * can only ever mean *rounds played*, counted from slots.
+ */
+
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+import { now, timestamp } from "./columns";
+import { events } from "./create_table_events";
+import { members } from "./create_table_members";
+
+export const eventRsvps = sqliteTable(
+  "event_rsvps",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+
+    eventId: integer("event_id")
+      .notNull()
+      .references(() => events.id),
+
+    /** NULL = «не впізнано» — no alias matched. */
+    memberId: text("member_id").references(() => members.id),
+
+    /** Kept even on a match, so a wrong match is visible rather than silent. */
+    apolloRawName: text("apollo_raw_name").notNull(),
+
+    status: text("status").notNull(),
+
+    importedAt: timestamp("imported_at").notNull().default(now),
+  },
+  (t) => [index("event_rsvps_event_idx").on(t.eventId)],
+);
+
+export type EventRsvp = typeof eventRsvps.$inferSelect;
+export type NewEventRsvp = typeof eventRsvps.$inferInsert;

--- a/src/db/schema/create_table_events.ts
+++ b/src/db/schema/create_table_events.ts
@@ -1,0 +1,31 @@
+/**
+ * A scrim night, imported from an Apollo RSVP embed.
+ *
+ * The event owns its own date, copied from Apollo at import rather than
+ * derived from it, so the roster survives Apollo being retired (#11).
+ */
+
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+import { timestamp } from "./columns";
+
+export const events = sqliteTable("events", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+
+  apolloMessageLink: text("apollo_message_link").notNull(),
+  apolloMessageId: text("apollo_message_id").notNull(),
+
+  date: timestamp("date").notNull(),
+
+  /**
+   * NULL = draft. «Publish» names this state transition, not the message —
+   * see the note in `CONTEXT.md`.
+   */
+  publishedAt: timestamp("published_at"),
+
+  /** The Roster post. Edited in place for the event's whole life. */
+  discordMessageId: text("discord_message_id"),
+});
+
+export type Event = typeof events.$inferSelect;
+export type NewEvent = typeof events.$inferInsert;

--- a/src/db/schema/create_table_member_aliases.ts
+++ b/src/db/schema/create_table_member_aliases.ts
@@ -1,0 +1,25 @@
+/**
+ * Apollo display name → Member.
+ *
+ * The only part of the RSVP import that survives the purge: an SL's manual
+ * correction («`kotyara` is Kotyara_UA») has to outlive the event it was made
+ * on. It stores a name and a Member and nothing else — no dates, no event
+ * reference, nothing about participation.
+ *
+ * Stays empty and gets deleted outright if Apollo turns out to emit real
+ * Discord IDs (#9's open question, folded into #14).
+ */
+
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+import { members } from "./create_table_members";
+
+export const memberAliases = sqliteTable("member_aliases", {
+  alias: text("alias").primaryKey(),
+  memberId: text("member_id")
+    .notNull()
+    .references(() => members.id),
+});
+
+export type MemberAlias = typeof memberAliases.$inferSelect;
+export type NewMemberAlias = typeof memberAliases.$inferInsert;

--- a/src/db/schema/create_table_member_roles.ts
+++ b/src/db/schema/create_table_member_roles.ts
@@ -1,0 +1,49 @@
+/**
+ * Squad-role capability.
+ *
+ * The row existing *is* «може» — which makes the roster builder's central
+ * question, «хто ще може сісти в танк?», a single indexed read.
+ */
+
+import {
+  index,
+  integer,
+  primaryKey,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+import { SQUAD_ROLES } from "@/consts/squad";
+
+import { members } from "./create_table_members";
+
+export const memberRoles = sqliteTable(
+  "member_roles",
+  {
+    memberId: text("member_id")
+      .notNull()
+      .references(() => members.id),
+
+    role: text("role", { enum: SQUAD_ROLES }).notNull(),
+
+    /**
+     * 1–3, the top-3 order. Nullable, and a **maximum not a quota** — 0 to 3
+     * preferences are all valid, because demanding three would block exactly
+     * the half-filled profiles the roster builder needs to see.
+     *
+     * Because a preference can only sit on a capability row, preferring a
+     * Squad role you cannot play is unrepresentable.
+     */
+    preference: integer("preference"),
+  },
+  (t) => [
+    primaryKey({ columns: [t.memberId, t.role] }),
+    // Makes a corrupt top-3 (two firsts) unrepresentable.
+    uniqueIndex("member_roles_preference_idx").on(t.memberId, t.preference),
+    index("member_roles_role_idx").on(t.role),
+  ],
+);
+
+export type MemberRole = typeof memberRoles.$inferSelect;
+export type NewMemberRole = typeof memberRoles.$inferInsert;

--- a/src/db/schema/create_table_members.ts
+++ b/src/db/schema/create_table_members.ts
@@ -1,0 +1,69 @@
+/**
+ * One row per person who has ever been in the guild.
+ *
+ * Rows are never deleted: published rosters are history, and removing a
+ * Member would retroactively rewrite past scrims and silently shift chemistry
+ * counts. Naming follows `CONTEXT.md` — the person is a **Member**, not a
+ * player. (#13 wrote `players`; the ubiquitous language overrides it.)
+ */
+
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+import { DIRECTIONS, RANKS } from "@/consts/squad";
+
+import { now, timestamp } from "./columns";
+
+export const members = sqliteTable(
+  "members",
+  {
+    /** Discord snowflake. TEXT, never INTEGER — snowflakes exceed 2^53. */
+    id: text("id").primaryKey(),
+
+    /** Last known callsign, overwritten by the guild sync. */
+    callsign: text("callsign").notNull(),
+
+    /**
+     * Denormalised from the guild sync for display and filtering.
+     * May never drive a permission gate — the tier is resolved live from the
+     * session on every request (#12), and never reads this column.
+     */
+    rank: text("rank", { enum: RANKS }).notNull(),
+
+    rolesSyncedAt: timestamp("roles_synced_at"),
+
+    /** Officer-only when read for anyone but the Member themselves (#12). */
+    steamId: text("steam_id"),
+
+    directionPrimary: text("direction_primary", { enum: DIRECTIONS }),
+    directionSecondary: text("direction_secondary", { enum: DIRECTIONS }),
+
+    /**
+     * Write-only. No site surface renders these — exactly one read path, for
+     * the greeting, plus the Member's own profile form. Three columns rather
+     * than one date so «14 березня» can be given without inventing a year.
+     */
+    birthDay: integer("birth_day"),
+    birthMonth: integer("birth_month"),
+    birthYear: integer("birth_year"),
+
+    /**
+     * Not `is_active`: `Inactive` is a Rank held by members who have *not*
+     * left. Set by the guild sync when an ID present yesterday is absent
+     * today — and only when the fetch succeeded with a plausible member
+     * count, since a half-failed fetch looks identical to a mass exodus.
+     */
+    isLeft: integer("is_left", { mode: "boolean" }).notNull().default(false),
+
+    createdAt: timestamp("created_at").notNull().default(now),
+    updatedAt: timestamp("updated_at").notNull().default(now),
+  },
+  (t) => [
+    // The one read path for birthdays.
+    index("members_birthday_idx").on(t.birthMonth, t.birthDay),
+    // The directory, and «хто ще не заповнив?».
+    index("members_is_left_idx").on(t.isLeft),
+  ],
+);
+
+export type Member = typeof members.$inferSelect;
+export type NewMember = typeof members.$inferInsert;

--- a/src/db/schema/create_table_rounds.ts
+++ b/src/db/schema/create_table_rounds.ts
@@ -1,0 +1,31 @@
+/**
+ * A scrim is N rosters, one per round — the faction changes, and the roster
+ * changes with it. So squads and slots hang off a round, not the event (#11).
+ *
+ * The round carries its own permanent id: identity-by-content would orphan
+ * every rating hanging beneath it the moment a published roster is edited.
+ */
+
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+import { events } from "./create_table_events";
+
+export const rounds = sqliteTable(
+  "rounds",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+
+    eventId: integer("event_id")
+      .notNull()
+      .references(() => events.id),
+
+    ordinal: integer("ordinal").notNull(),
+
+    faction: text("faction").notNull(),
+    layer: text("layer").notNull(),
+  },
+  (t) => [index("rounds_event_idx").on(t.eventId)],
+);
+
+export type Round = typeof rounds.$inferSelect;
+export type NewRound = typeof rounds.$inferInsert;

--- a/src/db/schema/create_table_slots.ts
+++ b/src/db/schema/create_table_slots.ts
@@ -1,0 +1,49 @@
+/**
+ * One Member in one squad in one round.
+ *
+ * Carries its own permanent id because ratings hang off it: identity-by-
+ * content would orphan them the moment a published roster is edited. Never
+ * hard-deleted, for the same reason.
+ */
+
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+import { SQUAD_ROLES } from "@/consts/squad";
+
+import { now, timestamp } from "./columns";
+import { members } from "./create_table_members";
+import { squads } from "./create_table_squads";
+
+export const slots = sqliteTable(
+  "slots",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+
+    squadId: integer("squad_id")
+      .notNull()
+      .references(() => squads.id),
+
+    memberId: text("member_id")
+      .notNull()
+      .references(() => members.id),
+
+    /**
+     * The Squad role actually played here — two of the six rating criteria
+     * are kit-relative, so «what were they doing» has to be recorded.
+     */
+    role: text("role", { enum: SQUAD_ROLES }),
+
+    /** Soft delete, always. A removed slot keeps its ratings and its history. */
+    removedAt: timestamp("removed_at"),
+
+    createdAt: timestamp("created_at").notNull().default(now),
+  },
+  (t) => [
+    index("slots_squad_idx").on(t.squadId),
+    // Chemistry and «rosters I played in» both start here.
+    index("slots_member_idx").on(t.memberId),
+  ],
+);
+
+export type Slot = typeof slots.$inferSelect;
+export type NewSlot = typeof slots.$inferInsert;

--- a/src/db/schema/create_table_squads.ts
+++ b/src/db/schema/create_table_squads.ts
@@ -1,0 +1,38 @@
+/**
+ * Freeform squads, with the напрямок as an optional type tag.
+ *
+ * Freeform because scrim sizes vary 20/26/36 and vics are sometimes their own
+ * squad and sometimes not — the tag lets the builder warn («цей інф сквад без
+ * медика») without dictating structure.
+ */
+
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+import { DIRECTIONS } from "@/consts/squad";
+
+import { rounds } from "./create_table_rounds";
+
+export const squads = sqliteTable(
+  "squads",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+
+    roundId: integer("round_id")
+      .notNull()
+      .references(() => rounds.id),
+
+    name: text("name").notNull(),
+
+    /**
+     * The six напрями, per #18 — the same enum as `members.direction_*`,
+     * because a напрямок *is* a type of загін rather than a position on the
+     * map. (#13's «Інфантрі | Армор | Логі» was invented during charting and
+     * is superseded.)
+     */
+    typeTag: text("type_tag", { enum: DIRECTIONS }),
+  },
+  (t) => [index("squads_round_idx").on(t.roundId)],
+);
+
+export type Squad = typeof squads.$inferSelect;
+export type NewSquad = typeof squads.$inferInsert;

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,0 +1,16 @@
+/**
+ * The schema, one file per table, as settled in issue #13.
+ *
+ * Table names are plural; foreign key columns stay singular. Enums are
+ * TypeScript-only, from `src/consts/squad.ts` — see the note there on why
+ * there are no CHECK constraints and no lookup tables.
+ */
+
+export * from "./create_table_members";
+export * from "./create_table_member_roles";
+export * from "./create_table_member_aliases";
+export * from "./create_table_events";
+export * from "./create_table_event_rsvps";
+export * from "./create_table_rounds";
+export * from "./create_table_squads";
+export * from "./create_table_slots";

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { readServerEnv } from "./env";
+import { readServerEnv, resolveTarget } from "./env";
 
 const complete = {
   DISCORD_BOT_TOKEN: "bot-token",
@@ -113,5 +113,85 @@ describe("readServerEnv", () => {
     });
 
     expect(result.ok).toBe(true);
+  });
+});
+
+const completeDev = {
+  DISCORD_DEV_BOT_TOKEN: "dev-bot-token",
+  DISCORD_DEV_CLIENT_ID: "1539396258769412196",
+  DISCORD_DEV_CLIENT_SECRET: "dev-client-secret",
+  DISCORD_DEV_REDIRECT_URI: "http://localhost:3000/api/auth/callback",
+  TURSO_DEV_DATABASE_URL: "libsql://rats-site-dev.turso.io",
+  TURSO_DEV_AUTH_TOKEN: "dev-turso-token",
+};
+
+describe("the development target", () => {
+  it("reads only the _DEV_ names", () => {
+    const result = readServerEnv(completeDev, "development");
+
+    expect(result).toEqual({
+      ok: true,
+      config: {
+        discordBotToken: "dev-bot-token",
+        discordClientId: "1539396258769412196",
+        discordClientSecret: "dev-client-secret",
+        discordRedirectUri: "http://localhost:3000/api/auth/callback",
+        tursoDatabaseUrl: "libsql://rats-site-dev.turso.io",
+        tursoAuthToken: "dev-turso-token",
+      },
+    });
+  });
+
+  it("never falls back to a production credential", () => {
+    // The whole point of the split: a half-configured dev setup must fail
+    // loudly rather than quietly writing to the clan's real database.
+    const result = readServerEnv(
+      { ...completeDev, TURSO_DEV_DATABASE_URL: undefined, ...complete },
+      "development",
+    );
+
+    expect(result.ok === false && result.problems).toEqual([
+      { key: "TURSO_DEV_DATABASE_URL", reason: "missing" },
+    ]);
+  });
+
+  it("names the _DEV_ variable in the problem, so the fix is unambiguous", () => {
+    const result = readServerEnv({}, "development");
+
+    expect(result.ok === false && result.problems.map((p) => p.key)).toEqual([
+      "DISCORD_DEV_BOT_TOKEN",
+      "DISCORD_DEV_CLIENT_ID",
+      "DISCORD_DEV_CLIENT_SECRET",
+      "DISCORD_DEV_REDIRECT_URI",
+      "TURSO_DEV_DATABASE_URL",
+      "TURSO_DEV_AUTH_TOKEN",
+    ]);
+  });
+});
+
+describe("resolveTarget", () => {
+  it("treats a Vercel preview as development", () => {
+    // A preview branch is where the registration flow gets tested with
+    // invented profiles; those must not land in the clan's real database.
+    expect(resolveTarget({ VERCEL_ENV: "preview" })).toBe("development");
+  });
+
+  it("treats a Vercel production deployment as production", () => {
+    expect(resolveTarget({ VERCEL_ENV: "production" })).toBe("production");
+  });
+
+  it("follows NODE_ENV when Vercel is not the host", () => {
+    expect(resolveTarget({ NODE_ENV: "development" })).toBe("development");
+  });
+
+  it("defaults to production, so scripts check the real services", () => {
+    expect(resolveTarget({})).toBe("production");
+    expect(resolveTarget({ NODE_ENV: "test" })).toBe("production");
+  });
+
+  it("lets APP_ENV override the host's own signal", () => {
+    expect(resolveTarget({ APP_ENV: "development", VERCEL_ENV: "production" })).toBe(
+      "development",
+    );
   });
 });

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -6,6 +6,13 @@
  * appear under a `NEXT_PUBLIC_` name — that would inline the value into the
  * client bundle. Non-secret Discord IDs (guild, roles, channels) are not env
  * vars at all; they live in `src/consts/discord.ts`.
+ *
+ * **Two targets.** Every credential exists twice: once for the real clan
+ * services, once for their throwaway development counterparts — the `rats-
+ * site-dev` database and the `RATS HQ Dev` application in its test guild
+ * (#29). The development names carry a `_DEV_` infix. Resolution picks one
+ * target and reads only that target's names, so a half-configured dev setup
+ * can never silently fall through to production and write to real data.
  */
 
 export interface ServerEnv {
@@ -17,45 +24,94 @@ export interface ServerEnv {
   tursoAuthToken: string;
 }
 
-const KEYS = {
-  DISCORD_BOT_TOKEN: "discordBotToken",
-  DISCORD_CLIENT_ID: "discordClientId",
-  DISCORD_CLIENT_SECRET: "discordClientSecret",
-  DISCORD_REDIRECT_URI: "discordRedirectUri",
-  TURSO_DATABASE_URL: "tursoDatabaseUrl",
-  TURSO_AUTH_TOKEN: "tursoAuthToken",
-} as const satisfies Record<string, keyof ServerEnv>;
+/** Which set of services the process should talk to. */
+export type EnvTarget = "development" | "production";
 
-export type ServerEnvKey = keyof typeof KEYS;
+const KEYS = {
+  discordBotToken: {
+    production: "DISCORD_BOT_TOKEN",
+    development: "DISCORD_DEV_BOT_TOKEN",
+  },
+  discordClientId: {
+    production: "DISCORD_CLIENT_ID",
+    development: "DISCORD_DEV_CLIENT_ID",
+  },
+  discordClientSecret: {
+    production: "DISCORD_CLIENT_SECRET",
+    development: "DISCORD_DEV_CLIENT_SECRET",
+  },
+  discordRedirectUri: {
+    production: "DISCORD_REDIRECT_URI",
+    development: "DISCORD_DEV_REDIRECT_URI",
+  },
+  tursoDatabaseUrl: {
+    production: "TURSO_DATABASE_URL",
+    development: "TURSO_DEV_DATABASE_URL",
+  },
+  tursoAuthToken: {
+    production: "TURSO_AUTH_TOKEN",
+    development: "TURSO_DEV_AUTH_TOKEN",
+  },
+} as const satisfies Record<keyof ServerEnv, Record<EnvTarget, string>>;
+
+/** The name of an environment variable this module reads. */
+export type ServerEnvKey =
+  (typeof KEYS)[keyof ServerEnv][EnvTarget];
 
 export type EnvResult =
   | { ok: true; config: ServerEnv }
   | { ok: false; problems: EnvProblem[] };
 
 export interface EnvProblem {
+  /** The variable actually looked up, so the fix is unambiguous. */
   key: ServerEnvKey;
   /** `exposed` — the value was found under a `NEXT_PUBLIC_` alias. */
   reason: "missing" | "exposed" | "invalid";
 }
 
-/** Per-key shape checks, to catch the paste errors that look plausible. */
-const SHAPE: Partial<Record<ServerEnvKey, (value: string) => boolean>> = {
+/** Per-field shape checks, to catch the paste errors that look plausible. */
+const SHAPE: Partial<Record<keyof ServerEnv, (value: string) => boolean>> = {
   // libsql:// and https:// are Turso; file: is the self-hosted exit path.
-  TURSO_DATABASE_URL: (v) => /^(libsql|https|file):/.test(v),
+  tursoDatabaseUrl: (v) => /^(libsql|https|file):/.test(v),
   // Discord matches redirect URIs exactly, so it must be absolute.
-  DISCORD_REDIRECT_URI: (v) => /^https?:\/\/.+/.test(v),
+  discordRedirectUri: (v) => /^https?:\/\/.+/.test(v),
 };
+
+/**
+ * Which services this process should be talking to.
+ *
+ * Vercel's own `VERCEL_ENV` is the authority where it exists, and **preview
+ * counts as development**: a preview branch is exactly where the registration
+ * flow gets tested with invented profiles, which must not land in the clan's
+ * real database. Everything else — CI, `vitest`, one-off `tsx` scripts —
+ * defaults to production, because those either supply their own variables or
+ * are checking the real services on purpose.
+ */
+export function resolveTarget(
+  env: Partial<Record<string, string>> = process.env,
+): EnvTarget {
+  if (env.APP_ENV === "development" || env.APP_ENV === "production") {
+    return env.APP_ENV;
+  }
+  if (env.VERCEL_ENV) {
+    return env.VERCEL_ENV === "production" ? "production" : "development";
+  }
+  return env.NODE_ENV === "development" ? "development" : "production";
+}
 
 export function readServerEnv(
   env: Partial<Record<string, string>>,
+  target: EnvTarget = resolveTarget(env),
 ): EnvResult {
   const config = {} as ServerEnv;
   const problems: EnvProblem[] = [];
 
-  for (const [key, field] of Object.entries(KEYS) as [
-    ServerEnvKey,
+  for (const [field, names] of Object.entries(KEYS) as [
     keyof ServerEnv,
+    Record<EnvTarget, ServerEnvKey>,
   ][]) {
+    const key = names[target];
+
     // A NEXT_PUBLIC_ alias is a leak whether or not the private name is also
     // set: Next.js inlines it into the client bundle at build time.
     if (env[`NEXT_PUBLIC_${key}`]?.trim()) {
@@ -69,7 +125,7 @@ export function readServerEnv(
       continue;
     }
 
-    if (SHAPE[key] && !SHAPE[key](value)) {
+    if (SHAPE[field] && !SHAPE[field](value)) {
       problems.push({ key, reason: "invalid" });
       continue;
     }


### PR DESCRIPTION
Closes #13.

## What

Eight tables, one file per table, Drizzle over `@libsql/client`, applied to the dev database and verified by querying it. Plus the dev/production split of every credential that makes a throwaway target possible in the first place.

### Schema

`members`, `member_aliases`, `member_roles`, `squads`, `slots`, `events`, `event_rsvps`, `rounds` — as settled in #13.

Two deliberate deviations from #13's resolution:

- **`members`, not `players`.** `CONTEXT.md` defines the person as a Member and explicitly says to avoid "Player"; #11 had already drifted to `rater_member_id`. Free to settle now, a migration later.
- **`squads.type_tag` carries the six напрями**, not #13's «Інфантрі | Армор | Логі», which #18 superseded. A напрямок is a type of загін, so the same enum serves it and `members.direction_*`.

Enums live in `src/consts/squad.ts` as `as const` arrays — no CHECK constraints, no lookup tables, because SQLite cannot ALTER a constraint and this taxonomy only changes when Squad itself does.

Adds the Recruit and Inactive role IDs that #12 and #13 both flagged as blocking `members.rank`.

### Credential split

The clan's real database and Discord application now have throwaway counterparts — `rats-site-dev` and the RATS HQ Dev application in its test guild (#29). Resolution picks one target and reads only that target's names, which carry a `_DEV_` infix.

There is deliberately **no fallback** from a development name to its production counterpart. A half-configured dev setup has to fail loudly; the alternative is quietly writing invented profiles into the clan's real data, which is the exact hazard the second database exists to remove.

Vercel previews resolve to development for the same reason. One-off scripts default to production, because \`make check-provisioning\` is meant to be checking the real services. \`ServerEnv\`'s shape is unchanged, so nothing that consumes it moved.

## Migrations

\`make db-migrate\` targets the dev database. Production needs \`make db-migrate-prod\`, by name.

## Checks

\`make check\` — lint, typecheck, 48 tests passing.