### PR TITLE
docs: record that assessment attributes are never stored

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,6 +72,14 @@ _Avoid_: Weight table (the thing it replaced — weights are signed and a profil
 How well a player's Риси match a Профіль напрямку — the assessment's output, one figure per Напрямок. It is **relative, not a probability**: «ФЛАНГ 83%» means this Напрямок is much more the player than the others are, never that they belong there with 83% certainty. A low Схильність floors its Напрямок's Відповідність near the bottom without removing it, so the result always shows all six.
 _Avoid_: Score, match percentage, confidence (killed as a figure — the model has no basis for one), fit (in Ukrainian copy)
 
+**Рівний результат**:
+An assessment that names two Напрями rather than one, because nothing in the answers separates them — the top two are within fifteen displayed points, or every Риса landed mid-range. Its opposite is a **чіткий результат**, which names one. Рівний is a real answer and never an error state: «ти ще не знаєш — ось що спробувати» is a true thing to tell a player, and the two Напрями are presented unordered because ordering them would assert a difference the model did not find.
+_Avoid_: Tie, inconclusive, low confidence, unclear
+
+**Вибір гравця**:
+The Напрямок a player picks for themselves after reading their result — asked as a choice, never as agreement or disagreement with the recommendation, and always asked last, because asking it first would colour every answer before it. It is what becomes the Member's primary Напрямок. A Вибір гравця that differs from the Відповідність is not a failure of the assessment and is not stored as a disagreement: the Відповідність is recomputable from the Атрибути, so the divergence is always visible without recording it.
+_Avoid_: Preference (unqualified — see Схильність), stated preference, agreement, override
+
 **Шортколер**:
 The player calling the shots for the team during a scrim, alongside or as CMD. Not a Напрямок and not a Squad role — like CMD, a hat worn for a match. Appears in assessment copy as «CMD/Шортколер».
 _Avoid_: Shotcaller (in Ukrainian copy), IGL, каптан

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,7 +53,7 @@ One of the ten in-game kits a Member can play — «Роль» — listed in `sr
 _Avoid_: Role (unqualified), kit, class, loadout, Tech light/middle/heavy (removed)
 
 **Атрибут**:
-A single 0–100 measure of what a player *wants* from a match, produced by the Squad Assessment tool and never observed from play. Two kinds — a Риса and a Схильність — and the pair of them is the entire vocabulary the assessment's scoring is written against. An Атрибут is always an appetite, never a claim of skill: the tool cannot know how well someone shoots, only what they want the match to turn on.
+A single 0–100 measure of what a player *wants* from a match, produced by the Squad Assessment tool and never observed from play. Two kinds — a Риса and a Схильність — and the pair of them is the entire vocabulary the assessment's scoring is written against. An Атрибут is always an appetite, never a claim of skill: the tool cannot know how well someone shoots, only what they want the match to turn on. **It is never stored**: an Атрибут is computed, shown to the player who answered, and discarded — no Member row holds one and no officer ever reads one.
 _Avoid_: Trait (unqualified), stat, score, rating, personality
 
 **Риса**:
@@ -77,7 +77,7 @@ An assessment that names two Напрями rather than one, because nothing in 
 _Avoid_: Tie, inconclusive, low confidence, unclear
 
 **Вибір гравця**:
-The Напрямок a player picks for themselves after reading their result — asked as a choice, never as agreement or disagreement with the recommendation, and always asked last, because asking it first would colour every answer before it. It is what becomes the Member's primary Напрямок. A Вибір гравця that differs from the Відповідність is not a failure of the assessment and is not stored as a disagreement: the Відповідність is recomputable from the Атрибути, so the divergence is always visible without recording it.
+The Напрямок a player picks for themselves after reading their result — asked as a choice, never as agreement or disagreement with the recommendation, and always asked last, because asking it first would colour every answer before it. It is what becomes the Member's primary Напрямок. A Вибір гравця that differs from the Відповідність is not a failure of the assessment and is not recorded as a disagreement — it is visible to the player on the result screen at the moment of choosing, and nowhere afterwards to anyone, because the Атрибути it was weighed against are gone. It is the only thing the assessment leaves behind, alongside the kits the player ticked.
 _Avoid_: Preference (unqualified — see Схильність), stated preference, agreement, override
 
 **Шортколер**:


### PR DESCRIPTION
Closes the `CONTEXT.md` half of #53.

#53 settled that the Squad Assessment tool **persists nothing it measures** — no Атрибути, no answers, no Відповідність, no version, not even a timestamp. One save writes `members.direction_primary` and `member_roles` capability rows, both ordinary profile fields. No schema change.

Two glossary entries follow from that:

- **Атрибут** gains its lifetime — computed, shown to the player who answered, discarded. No Member row holds one and no officer ever reads one.
- **Вибір гравця** is **corrected**. It claimed the divergence from the Відповідність «is always visible without recording it» because the Відповідність is recomputable from the Атрибути. That is false now that none are stored. The divergence is visible to the player on the result screen at the moment of choosing, and nowhere afterwards to anyone.

Docs only — no code touched.